### PR TITLE
Prevent sending the size option with Streams

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -154,7 +154,10 @@ export class Gaxios {
 
     opts.url = parsedUrl.href;
 
-    if (typeof options.maxContentLength === 'number') {
+    if (
+      (!opts.data || !this.isReadableStream(opts.data)) &&
+      typeof options.maxContentLength === 'number'
+    ) {
       opts.size = options.maxContentLength;
     }
 

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -44,7 +44,7 @@ describe('🦖 option validation', () => {
     assertRejects(request({}), /URL is required/);
   });
 
-  it('should set content-length when data is a readable stream', async () => {
+  it('should set content-length when data is not a readable stream', async () => {
     const data = 'foo';
     const scope = nock(url)
       .matchHeader(

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -43,6 +43,38 @@ describe('🦖 option validation', () => {
   it('should throw an error if a url is not provided', () => {
     assertRejects(request({}), /URL is required/);
   });
+
+  it('should set content-length when data is a readable stream', async () => {
+    const data = 'foo';
+    const scope = nock(url)
+      .matchHeader(
+        'content-length',
+        length => length[0] === data.length.toString()
+      )
+      .post('/')
+      .reply(200, {});
+    const res = await request({
+      url,
+      method: 'POST',
+      maxContentLength: 2048,
+      data,
+    });
+    scope.done();
+  });
+
+  it('should not set content-length when data is a readable stream', async () => {
+    const scope = nock(url)
+      .matchHeader('content-length', length => length === undefined)
+      .post('/')
+      .reply(200, {});
+    const res = await request({
+      url,
+      method: 'POST',
+      maxContentLength: 2048,
+      data: fs.createReadStream('package.json'),
+    });
+    scope.done();
+  });
 });
 
 describe('🚙 error handling', () => {


### PR DESCRIPTION
Since stream data should be sent using `Transfer-Encoding: Chunked`
rather than an exact `Content-Length` we should not default to setting
the size parameter unless we know the actual byte length of the payload.
This is an additional improvement to fix the issue outlined here:
https://github.com/bitinn/node-fetch/pull/637