### PR TITLE
fix: do not override content-type if its given

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -187,7 +187,11 @@ export class Gaxios {
         opts.body = opts.data;
       } else if (typeof opts.data === 'object') {
         opts.body = JSON.stringify(opts.data);
-        if (!Object.keys(opts.headers).some((key: string) => key.match(/^content-type$/i))) {
+        if (
+          !Object.keys(opts.headers).some((key: string) =>
+            key.match(/^content-type$/i)
+          )
+        ) {
           opts.headers['Content-Type'] = 'application/json';
         }
       } else {

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -301,12 +301,12 @@ describe('🎏 data handling', () => {
     const res = await request({
       url,
       method: 'POST',
-      data: body
+      data: body,
     });
     scope.done();
     assert.deepStrictEqual(res.data, {});
   });
-  
+
   it('should allow to override content-type for object request', async () => {
     const body = {hello: '🌎'};
     const scope = nock(url)
@@ -317,7 +317,7 @@ describe('🎏 data handling', () => {
       url,
       method: 'POST',
       data: body,
-      headers: {'content-type': 'application/octet-stream'}
+      headers: {'content-type': 'application/octet-stream'},
     });
     scope.done();
     assert.deepStrictEqual(res.data, {});


### PR DESCRIPTION
Fixes #156 by forcing the `Content-Type` header only it's not set in options. It should work then because the header is set in https://github.com/googleapis/nodejs-googleapis-common/blob/8734154a219c3a2bf865dc830bc95fbb5a640794/src/apirequest.ts#L210 and should be just passed down all the way.