### PR TITLE
fix!: change type of agent option to match node-fetch

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 import {AbortSignal} from 'abort-controller';
-import {Agent} from 'https';
+import {Agent} from 'http';
+import {URL} from 'url';
 
 // tslint:disable no-any
 
@@ -84,7 +85,7 @@ export interface GaxiosOptions {
   timeout?: number;
   onUploadProgress?: (progressEvent: any) => void;
   responseType?: 'arraybuffer' | 'blob' | 'json' | 'text' | 'stream';
-  agent?: Agent;
+  agent?: Agent | ((parsedUrl: URL) => Agent);
   validateStatus?: (status: number) => boolean;
   retryConfig?: RetryConfig;
   retry?: boolean;

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import extend from 'extend';
-import {Agent} from 'https';
+import {Agent} from 'http';
 import nodeFetch, {Response as NodeFetchResponse} from 'node-fetch';
 import qs from 'querystring';
 import stream from 'stream';
@@ -64,7 +64,10 @@ function loadProxy() {
 loadProxy();
 
 export class Gaxios {
-  private agentCache = new Map<string, Agent>();
+  private agentCache = new Map<
+    string,
+    Agent | ((parsedUrl: url.URL) => Agent)
+  >();
 
   /**
    * Default HTTP options that will be used for every HTTP request.


### PR DESCRIPTION
node-fetch accepts either an http.Agent or function that returns one as the
agent option, but gaxios only accepts a https.Agent. Instead use the type from
node-fetch since gaxios simply forwards the option to fetch.

Docs: https://www.npmjs.com/package/node-fetch
"http(s).Agent instance or function that returns an instance"