### PR TITLE
feat: populate GaxiosResponse with raw response information (res.url)

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -40,8 +40,6 @@ export type GaxiosPromise<T = any> = Promise<GaxiosResponse<T>>;
 
 export interface GaxiosXMLHttpRequest {
   responseURL: string;
-  status: number;
-  statusText: string;
 }
 
 export interface GaxiosResponse<T = any> {

--- a/src/common.ts
+++ b/src/common.ts
@@ -38,12 +38,19 @@ export interface Headers {
 }
 export type GaxiosPromise<T = any> = Promise<GaxiosResponse<T>>;
 
+export interface GaxiosXMLHttpRequest {
+  responseURL: string;
+  status: number;
+  statusText: string;
+}
+
 export interface GaxiosResponse<T = any> {
   config: GaxiosOptions;
   data: T;
   status: number;
   statusText: string;
   headers: Headers;
+  request: GaxiosXMLHttpRequest;
 }
 
 /**

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -254,8 +254,6 @@ export class Gaxios {
       // XMLHttpRequestLike
       request: {
         responseURL: res.url,
-        status: res.status,
-        statusText: res.statusText,
       },
     };
   }

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -250,6 +250,13 @@ export class Gaxios {
       headers,
       status: res.status,
       statusText: res.statusText,
+
+      // XMLHttpRequestLike
+      request: {
+        responseURL: res.url,
+        status: res.status,
+        statusText: res.statusText,
+      },
     };
   }
 }

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -142,8 +142,6 @@ describe('🥁 configuration options', () => {
       headers: {},
       request: {
         responseURL: url,
-        status: 200,
-        statusText: 'OK',
       },
     };
     const adapter = (options: GaxiosOptions) => {

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -121,6 +121,7 @@ describe('🥁 configuration options', () => {
     const res = await request({url});
     scopes.forEach(x => x.done());
     assert.deepStrictEqual(res.data, body);
+    assert.strictEqual(res.request.responseURL, `${url}/foo`);
   });
 
   it('should support disabling redirects', async () => {
@@ -139,6 +140,11 @@ describe('🥁 configuration options', () => {
       status: 200,
       statusText: 'OK',
       headers: {},
+      request: {
+        responseURL: url,
+        status: 200,
+        statusText: 'OK',
+      },
     };
     const adapter = (options: GaxiosOptions) => {
       return Promise.resolve(response);


### PR DESCRIPTION
To resolve https://github.com/googleapis/gaxios/issues/187

Adding `request.responseUrl` with real URL after redirects to response.

```
await axios.get('/redirect')

{
 config: {
   url: '/redirect',
   ...
 },
 request: {
   responseURL: 'https://example.com/real_page',
 }
}
```