### PR TITLE
fix: don't retry a request that is aborted intentionally

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -19,7 +19,6 @@ import {URL} from 'url';
 
 export class GaxiosError<T = any> extends Error {
   code?: string;
-  type?: string;
   response?: GaxiosResponse<T>;
   config: GaxiosOptions;
   constructor(

--- a/src/common.ts
+++ b/src/common.ts
@@ -19,6 +19,7 @@ import {URL} from 'url';
 
 export class GaxiosError<T = any> extends Error {
   code?: string;
+  type?: string;
   response?: GaxiosResponse<T>;
   config: GaxiosOptions;
   constructor(

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -89,6 +89,12 @@ export async function getRetryConfig(err: GaxiosError) {
 function shouldRetryRequest(err: GaxiosError) {
   const config = getConfig(err);
 
+  // If the user has explicitly aborted the request, don't retry.
+  // "type" is populated on the error objects created by node-fetch.
+  if (err.type === 'aborted') {
+    return false;
+  }
+
   // If there's no config, or retries are disabled, return.
   if (!config || config.retry === 0) {
     return false;

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -89,9 +89,9 @@ export async function getRetryConfig(err: GaxiosError) {
 function shouldRetryRequest(err: GaxiosError) {
   const config = getConfig(err);
 
-  // If the user has explicitly aborted the request, don't retry.
-  // "type" is populated on the error objects created by node-fetch.
-  if (err.type === 'aborted') {
+  // node-fetch raises an AbortError if signaled:
+  // https://github.com/bitinn/node-fetch#request-cancellation-with-abortsignal
+  if (err.name === 'AbortError') {
     return false;
   }
 

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -55,7 +55,11 @@ describe('🛸 retry & exponential backoff', () => {
       for (const method of config!.httpMethodsToRetry!) {
         assert(expectedMethods.indexOf(method) > -1);
       }
-      const expectedStatusCodes = [[100, 199], [429, 429], [500, 599]];
+      const expectedStatusCodes = [
+        [100, 199],
+        [429, 429],
+        [500, 599],
+      ];
       const statusCodesToRetry = config!.statusCodesToRetry!;
       for (let i = 0; i < statusCodesToRetry.length; i++) {
         const [min, max] = statusCodesToRetry[i];

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -14,6 +14,7 @@
 import assert from 'assert';
 import nock from 'nock';
 
+import {AbortController} from 'abort-controller';
 import {GaxiosError, GaxiosOptions, request, Gaxios} from '../src';
 
 const assertRejects = require('assert-rejects');
@@ -54,11 +55,7 @@ describe('🛸 retry & exponential backoff', () => {
       for (const method of config!.httpMethodsToRetry!) {
         assert(expectedMethods.indexOf(method) > -1);
       }
-      const expectedStatusCodes = [
-        [100, 199],
-        [429, 429],
-        [500, 599],
-      ];
+      const expectedStatusCodes = [[100, 199], [429, 429], [500, 599]];
       const statusCodesToRetry = config!.statusCodesToRetry!;
       for (let i = 0; i < statusCodesToRetry.length; i++) {
         const [min, max] = statusCodesToRetry[i];
@@ -100,6 +97,25 @@ describe('🛸 retry & exponential backoff', () => {
       }
     );
     scope.done();
+  });
+
+  it('should not retry if user aborted request', async () => {
+    const ac = new AbortController();
+    const config: GaxiosOptions = {
+      method: 'GET',
+      url: 'https://google.com',
+      signal: ac.signal,
+      retryConfig: {retry: 10, noResponseRetries: 10},
+    };
+    const req = request(config);
+    ac.abort();
+    try {
+      await req;
+      throw Error('unreachable');
+    } catch (err) {
+      assert(err.config);
+      assert.strictEqual(err.config.retryConfig.currentRetryAttempt, 0);
+    }
   });
 
   it('should retry at least the configured number of times', async () => {


### PR DESCRIPTION
If a user has explicitly aborted a request, let's not retry it.

fixes #120 
