### PR TITLE
docs: correct comment on data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ gaxios.request({url: '/data'}).then(...);
   // The HTTP methods to be sent with the request.
   headers: { 'some': 'header' },
 
-  // The data to base64 encode and send in the body of the request.
+  // The data send in the body of the request. Objects will be converted to JSON.
   data: {
     some: 'data'
   },

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ gaxios.request({url: '/data'}).then(...);
   // The HTTP methods to be sent with the request.
   headers: { 'some': 'header' },
 
-  // The data send in the body of the request. Objects will be converted to JSON.
+  // The data to send in the body of the request. Data objects will be serialized as JSON.
   data: {
     some: 'data'
   },


### PR DESCRIPTION
The previous comment is incorrect, as data is not base64 encoded.

Fixes #209 🦕
