### PR TITLE
fix: continue replacing application/x-www-form-urlencoded with application/json

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -201,7 +201,10 @@ export class Gaxios {
         //
         // TODO: refactor upstream dependencies to stop relying on this
         // side-effect.
-        if (!opts.headers['Content-Type'] || !opts.headers['Content-Type'].includes('json')) {
+        if (
+          !opts.headers['Content-Type'] ||
+          !opts.headers['Content-Type'].includes('json')
+        ) {
           opts.headers['Content-Type'] = 'application/json';
         }
       } else {

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -194,8 +194,14 @@ export class Gaxios {
       } else if (typeof opts.data === 'object') {
         opts.body = JSON.stringify(opts.data);
         // Allow the user to specifiy their own content type,
-        // such as application/json-patch+json:
-        if (!opts.headers['Content-Type']) {
+        // such as application/json-patch+json; for historical reasons this
+        // content type must currently be a json type, as we are relying on
+        // application/x-www-form-urlencoded (which is incompatible with)
+        // upstream GCP APIs, being rewritten to application/json.
+        //
+        // TODO: refactor upstream dependencies to stop relying on this
+        // side-effect.
+        if (!opts.headers['Content-Type'] || !opts.headers['Content-Type'].includes('json')) {
           opts.headers['Content-Type'] = 'application/json';
         }
       } else {

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -196,8 +196,8 @@ export class Gaxios {
         // Allow the user to specifiy their own content type,
         // such as application/json-patch+json; for historical reasons this
         // content type must currently be a json type, as we are relying on
-        // application/x-www-form-urlencoded (which is incompatible with)
-        // upstream GCP APIs, being rewritten to application/json.
+        // application/x-www-form-urlencoded (which is incompatible with
+        // upstream GCP APIs) being rewritten to application/json.
         //
         // TODO: refactor upstream dependencies to stop relying on this
         // side-effect.

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -329,6 +329,24 @@ describe('🎏 data handling', () => {
     assert.deepStrictEqual(res.data, {});
   });
 
+  it('replaces application/x-www-form-urlencoded with application/json', async () => {
+    const body = {hello: '🌎'};
+    const scope = nock(url)
+      .matchHeader('Content-Type', 'application/json')
+      .post('/', JSON.stringify(body))
+      .reply(200, {});
+    const res = await request({
+      url,
+      method: 'POST',
+      data: body,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
+  });
+
   it('should return stream if asked nicely', async () => {
     const body = {hello: '🌎'};
     const scope = nock(url)


### PR DESCRIPTION
we rely on the side effect of application/x-www-form-urlencoded being replaced with application/json somewhere in our stack. This will need to be unraveled and fixed upstream. Also, we will need to treat applying `Content-Type` as a breaking change in the future.