### PR TITLE
fix!: drop requirement on URL/combine url and params

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -30,15 +30,10 @@ import {getRetryConfig} from './retry';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable node/no-unsupported-features/node-builtins */
 
-const URL = hasURL() ? window.URL : url.URL;
 const fetch = hasFetch() ? window.fetch : nodeFetch;
 
 function hasWindow() {
   return typeof window !== 'undefined' && !!window;
-}
-
-function hasURL() {
-  return hasWindow() && !!window.URL;
 }
 
 function hasFetch() {
@@ -174,19 +169,15 @@ export class Gaxios {
       opts.url = baseUrl + opts.url;
     }
 
-    const parsedUrl = new URL(opts.url);
-    opts.url = `${parsedUrl.origin}${parsedUrl.pathname}`;
-    opts.params = extend(
-      qs.parse(parsedUrl.search.substr(1)), // removes leading ?
-      opts.params
-    );
-
     opts.paramsSerializer = opts.paramsSerializer || this.paramsSerializer;
     if (opts.params) {
-      parsedUrl.search = opts.paramsSerializer(opts.params);
+      let additionalQueryParams = opts.paramsSerializer(opts.params);
+      if (additionalQueryParams.startsWith('?')) {
+        additionalQueryParams = additionalQueryParams.slice(1);
+      }
+      const prefix = opts.url.includes('?') ? '&' : '?';
+      opts.url = opts.url + prefix + additionalQueryParams;
     }
-
-    opts.url = parsedUrl.href;
 
     if (typeof options.maxContentLength === 'number') {
       opts.size = options.maxContentLength;

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -169,13 +169,24 @@ describe('🥁 configuration options', () => {
     scope.done();
   });
 
-  it('should encode parameters from the params option', async () => {
-    const opts = {url, params: {james: 'kirk', montgomery: 'scott'}};
-    const path = '/?james=kirk&montgomery=scott';
+  it('should preserve the original querystring', async () => {
+    const path = '/?robot';
+    const opts = {url: `${url}${path}`};
     const scope = nock(url).get(path).reply(200, {});
     const res = await request(opts);
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.config.url, url + path);
+    scope.done();
+  });
+
+  it('should encode parameters from the params option', async () => {
+    const opts = {url, params: {james: 'kirk', montgomery: 'scott'}};
+    const qs = '?james=kirk&montgomery=scott';
+    const path = `/${qs}`;
+    const scope = nock(url).get(path).reply(200, {});
+    const res = await request(opts);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.config.url, url + qs);
     scope.done();
   });
 
@@ -184,7 +195,7 @@ describe('🥁 configuration options', () => {
       url: `${url}/?james=beckwith&montgomery=scott`,
       params: {james: 'kirk'},
     };
-    const path = '/?james=kirk&montgomery=scott';
+    const path = '/?james=beckwith&montgomery=scott&james=kirk';
     const scope = nock(url).get(path).reply(200, {});
     const res = await request(opts);
     assert.strictEqual(res.status, 200);
@@ -206,7 +217,7 @@ describe('🥁 configuration options', () => {
     const scope = nock(url).get(`/${qs}`).reply(200, {});
     const res = await request(opts);
     assert.strictEqual(res.status, 200);
-    assert.strictEqual(res.config.url, `${url}/${qs}`);
+    assert.strictEqual(res.config.url, url + qs);
     scope.done();
   });
 


### PR DESCRIPTION
**This is a high risk change, please review carefully**

I think this would fix #331, and fix #320.  We currently use [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) to parse the provided url, and then re-build the whole thing after merging querystring parameters.  This was causing some issues for folks in #331 where the querystring parser doesn't really understand querystring properties with no values, and it was causing problems in #320 where CloudFlare Workers appear to not have a native `URL` available to them?  That's neat!  

This works around both problems by removing the use of `URL`, and doing a little hand crafting of the querystring.  Right now I have this as a `fix`...  I am open to conversations about the semverity of it though. 