### PR TITLE
fix: prevent bonus ? with empty qs params

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -170,7 +170,7 @@ export class Gaxios {
     }
 
     opts.paramsSerializer = opts.paramsSerializer || this.paramsSerializer;
-    if (opts.params) {
+    if (opts.params && Object.keys(opts.params).length > 0) {
       let additionalQueryParams = opts.paramsSerializer(opts.params);
       if (additionalQueryParams.startsWith('?')) {
         additionalQueryParams = additionalQueryParams.slice(1);

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -179,6 +179,16 @@ describe('🥁 configuration options', () => {
     scope.done();
   });
 
+  it('should handle empty querystring params', async () => {
+    const scope = nock(url).get('/').reply(200, {});
+    const res = await request({
+      url,
+      params: {},
+    });
+    assert.strictEqual(res.status, 200);
+    scope.done();
+  });
+
   it('should encode parameters from the params option', async () => {
     const opts = {url, params: {james: 'kirk', montgomery: 'scott'}};
     const qs = '?james=kirk&montgomery=scott';


### PR DESCRIPTION
When provided with an empty `params` option, we started applying a bonus `?` at the end of urls.  While mostly benign, this broke a bunch of our own tests.  