### PR TITLE
feat: handle application/x-www-form-urlencoded/Buffer

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -40,6 +40,19 @@ function hasFetch() {
   return hasWindow() && !!window.fetch;
 }
 
+function hasBuffer() {
+  return typeof Buffer !== 'undefined';
+}
+
+function hasHeader(options: GaxiosOptions, headerCheck: string) {
+  headerCheck = headerCheck.toLowerCase();
+  for (let header of Object.keys(options?.headers || {})) {
+    header = header.toLowerCase();
+    if (header === headerCheck) return true;
+  }
+  return false;
+}
+
 let HttpsProxyAgent: any;
 
 function loadProxy() {
@@ -219,21 +232,25 @@ export class Gaxios {
     if (opts.data) {
       if (isStream.readable(opts.data)) {
         opts.body = opts.data;
-      } else if (typeof opts.data === 'object') {
-        opts.body = JSON.stringify(opts.data);
-        // Allow the user to specifiy their own content type,
-        // such as application/json-patch+json; for historical reasons this
-        // content type must currently be a json type, as we are relying on
-        // application/x-www-form-urlencoded (which is incompatible with
-        // upstream GCP APIs) being rewritten to application/json.
-        //
-        // TODO: refactor upstream dependencies to stop relying on this
-        // side-effect.
-        if (
-          !opts.headers['Content-Type'] ||
-          !opts.headers['Content-Type'].includes('json')
-        ) {
+      } else if (hasBuffer() && Buffer.isBuffer(opts.data)) {
+        // Do not attempt to JSON.stringify() a Buffer:
+        opts.body = opts.data;
+        if (!hasHeader(opts, 'Content-Type')) {
           opts.headers['Content-Type'] = 'application/json';
+        }
+      } else if (typeof opts.data === 'object') {
+        // If www-form-urlencoded content type has been set, but data is
+        // provided as an object, serialize the content using querystring:
+        if (
+          opts.headers['Content-Type'] &&
+          opts.headers['Content-Type'] === 'application/x-www-form-urlencoded'
+        ) {
+          opts.body = opts.paramsSerializer(opts.data);
+        } else {
+          if (!hasHeader(opts, 'Content-Type')) {
+            opts.headers['Content-Type'] = 'application/json';
+          }
+          opts.body = JSON.stringify(opts.data);
         }
       } else {
         opts.body = opts.data;

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -44,13 +44,18 @@ function hasBuffer() {
   return typeof Buffer !== 'undefined';
 }
 
-function hasHeader(options: GaxiosOptions, headerCheck: string) {
-  headerCheck = headerCheck.toLowerCase();
-  for (let header of Object.keys(options?.headers || {})) {
-    header = header.toLowerCase();
-    if (header === headerCheck) return true;
+function hasHeader(options: GaxiosOptions, header: string) {
+  return !!getHeader(options, header);
+}
+
+function getHeader(options: GaxiosOptions, header: string): string | undefined {
+  header = header.toLowerCase();
+  for (const key of Object.keys(options?.headers || {})) {
+    if (header === key.toLowerCase()) {
+      return options.headers![key];
+    }
   }
-  return false;
+  return undefined;
 }
 
 let HttpsProxyAgent: any;
@@ -242,8 +247,8 @@ export class Gaxios {
         // If www-form-urlencoded content type has been set, but data is
         // provided as an object, serialize the content using querystring:
         if (
-          opts.headers['Content-Type'] &&
-          opts.headers['Content-Type'] === 'application/x-www-form-urlencoded'
+          getHeader(opts, 'content-type') ===
+          'application/x-www-form-urlencoded'
         ) {
           opts.body = opts.paramsSerializer(opts.data);
         } else {

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -449,7 +449,7 @@ describe('🎏 data handling', () => {
     assert.deepStrictEqual(res.data, {});
   });
 
-  it('application/x-www-form-urlencoded with object data should stringify with qs', async () => {
+  it('it should stringify with qs when content-type is set to application/x-www-form-urlencoded', async () => {
     const body = {hello: '🌎'};
     const scope = nock(url)
       .matchHeader('Content-Type', 'application/x-www-form-urlencoded')

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -449,11 +449,11 @@ describe('🎏 data handling', () => {
     assert.deepStrictEqual(res.data, {});
   });
 
-  it('replaces application/x-www-form-urlencoded with application/json', async () => {
+  it('application/x-www-form-urlencoded with object data should stringify with qs', async () => {
     const body = {hello: '🌎'};
     const scope = nock(url)
-      .matchHeader('Content-Type', 'application/json')
-      .post('/', JSON.stringify(body))
+      .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
+      .post('/', qs.stringify(body))
       .reply(200, {});
     const res = await request({
       url,
@@ -529,5 +529,38 @@ describe('🍂 defaults & instances', () => {
     const res = await gax.request();
     scope.done();
     assert.deepStrictEqual(res.data, body);
+  });
+
+  it('should allow buffer to be posted', async () => {
+    const pkg = fs.readFileSync('./package.json');
+    const pkgJson = JSON.parse(pkg.toString('utf8'));
+    const scope = nock(url)
+      .matchHeader('content-type', 'application/dicom')
+      .post('/', pkgJson)
+      .reply(200, {});
+    const res = await request({
+      url,
+      method: 'POST',
+      data: pkg,
+      headers: {'content-type': 'application/dicom'},
+    });
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
+  });
+
+  it('should set content-type to application/json by default, for buffer', async () => {
+    const pkg = fs.readFileSync('./package.json');
+    const pkgJson = JSON.parse(pkg.toString('utf8'));
+    const scope = nock(url)
+      .matchHeader('content-type', 'application/json')
+      .post('/', pkgJson)
+      .reply(200, {});
+    const res = await request({
+      url,
+      method: 'POST',
+      data: pkg,
+    });
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
   });
 });

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -449,7 +449,7 @@ describe('🎏 data handling', () => {
     assert.deepStrictEqual(res.data, {});
   });
 
-  it('it should stringify with qs when content-type is set to application/x-www-form-urlencoded', async () => {
+  it('should stringify with qs when content-type is set to application/x-www-form-urlencoded', async () => {
     const body = {hello: '🌎'};
     const scope = nock(url)
       .matchHeader('Content-Type', 'application/x-www-form-urlencoded')


### PR DESCRIPTION
Rather than switching `node-gtoken` to serializing its body with urlencoding, add support for `application/x-www-form-urlencoded` to gaxios.

This PR also corrects our handling of `Buffer` (otherwise allowing users to set a content-type header would not have corrected their issue).

Refs: https://github.com/googleapis/node-gtoken/pull/362
Refs: https://github.com/googleapis/node-gtoken/pull/363
Refs: googleapis/google-api-nodejs-client#2003
