### PR TITLE
chore: update node-fetch to ^2.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "extend": "^3.0.2",
     "https-proxy-agent": "^5.0.0",
     "is-stream": "^2.0.0",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.5"
   }
 }


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com//issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕

There was an issue with query parameters in node-fetch version 2.6.3. See https://github.com/node-fetch/node-fetch/pull/1301. The node-js storage library had a few people raising the issue (https://github.com/googleapis/nodejs-storage/issues/1600). I would like to update node-fetch to ^2.6.5 to avoid the bad version of node-fetch.
