### PR TITLE
fix(deps): node-fetch ^2.6.5 -> ^2.6.7 (security patch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "extend": "^3.0.2",
     "https-proxy-agent": "^5.0.0",
     "is-stream": "^2.0.0",
-    "node-fetch": "^2.6.5"
+    "node-fetch": "^2.6.7"
   }
 }


### PR DESCRIPTION
Ensures that the latest security patch from node-fetch version 2 is included.

It is technically not necessary, but it prevents problems with non-updated dependencies in user land.

Fixes #466  🦕
