### PR TITLE
Prevent reference error when run outside of nodejs

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -75,7 +75,7 @@ function loadProxy() {
 loadProxy();
 
 function skipProxy(url: string) {
-  const noProxyEnv = process.env.NO_PROXY ?? process.env.no_proxy;
+  const noProxyEnv = process?.env?.NO_PROXY ?? process?.env?.no_proxy;
   if (!noProxyEnv) {
     return false;
   }


### PR DESCRIPTION
Fix for #531,  use optional chaining for the other instance of `process` in `gaxios.ts`, so that it matches the one above

Fixes #531 🦕
