### PR TITLE
feat: Extend `instanceof` Support for `GaxiosError`

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,17 @@
+// Copyright 2023 Google LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const pkg: {
+  name: string;
+  version: string;
+} = require('../../package.json');

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -26,6 +26,8 @@ import {
   GaxiosResponse,
   GaxiosPromise,
 } from '../src';
+import {GAXIOS_ERROR_SYMBOL} from '../src/common';
+import {pkg} from '../src/util';
 import qs from 'querystring';
 import fs from 'fs';
 import {Blob} from 'node-fetch';
@@ -118,6 +120,18 @@ describe('🚙 error handling', () => {
 
     assert(error.response, undefined);
     assert.equal(error.response.data, notJSON);
+  });
+
+  it('should support `instanceof` for GaxiosErrors of the same version', () => {
+    class A extends GaxiosError {}
+
+    const wrongVersion = {[GAXIOS_ERROR_SYMBOL]: '0.0.0'};
+    const correctVersion = {[GAXIOS_ERROR_SYMBOL]: pkg.version};
+    const child = new A('', {});
+
+    assert.equal(wrongVersion instanceof GaxiosError, false);
+    assert.equal(correctVersion instanceof GaxiosError, true);
+    assert.equal(child instanceof GaxiosError, true);
   });
 });
 


### PR DESCRIPTION
## Improve `instanceOf` Support for `GaxiosError`

There are a number of reasons `instanceof` could provide false-negatives:
- https://github.com/microsoft/TypeScript/issues/13965#issuecomment-278570200
- https://stackoverflow.com/questions/46618852/require-and-instanceof

This PR aims to keep `instanceof` consistent and predictable across builds, in a supported, conventional way:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/@@hasInstance#reverting_to_default_instanceof_behavior

Background for why this is needed:
- https://github.com/googleapis/google-auth-library-nodejs/pull/1707
- https://github.com/googleapis/google-auth-library-nodejs/issues/1706

## Future Follow-ups

In the future we could create a utility to support the functionality for any class. E.g.:

```ts
function addInstanceOfSupport<T extends Function>(
  constructor: T,
  pkgInfo: typeof pkg
) {
  // Generate unique, predictable symbol
  const symbol = Symbol.for(`${pkgInfo.name}-${constructor.name}`);
  // Set symbol on constructor
  const c = constructor as unknown as {[symbol]: string};
  c[symbol] = pkgInfo.version;

  // keep original call
  const original = constructor[Symbol.hasInstance];

  function instanceofWithSymbolCheck(instance: unknown) {
    if (
      instance &&
      typeof instance === 'object' &&
      symbol in instance &&
      instance[symbol] === pkgInfo.version
    ) {
      return true;
    }

    // fallback to original call
    return original.call(constructor, instance);
  }

  constructor[Symbol.hasInstance] = instanceofWithSymbolCheck;
}

// example
addInstanceOfSupport(GaxiosError, pkg);
```

🦕
