### PR TITLE
feat: Enhance Error Redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ over other authentication methods, i.e., application default credentials.
    *
    * Set `false` to disable.
    *
+   * @remarks
+   *
+   * This does not replace the requirement for an active Data Loss Prevention (DLP) provider. For DLP suggestions, see:
+   * - https://cloud.google.com/sensitive-data-protection/docs/redacting-sensitive-data#dlp_deidentify_replace_infotype-nodejs
+   * - https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference#credentials_and_secrets
+   *
    * @experimental
    */
   errorRedactor?: typeof defaultErrorRedactor | false;

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "karma-mocha": "^2.0.0",
     "karma-remap-coverage": "^0.1.5",
     "karma-sourcemap-loader": "^0.4.0",
-    "karma-webpack": "^5.0.0",
+    "karma-webpack": "5.0.0",
     "linkinator": "^4.0.0",
     "mocha": "^8.0.0",
     "multiparty": "^4.2.1",

--- a/src/common.ts
+++ b/src/common.ts
@@ -209,6 +209,12 @@ export interface GaxiosOptions {
   /**
    * An experimental error redactor.
    *
+   * @remarks
+   *
+   * This does not replace the requirement for an active Data Loss Prevention (DLP) provider. For DLP suggestions, see:
+   * - https://cloud.google.com/sensitive-data-protection/docs/redacting-sensitive-data#dlp_deidentify_replace_infotype-nodejs
+   * - https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference#credentials_and_secrets
+   *
    * @experimental
    */
   errorRedactor?: typeof defaultErrorRedactor | false;

--- a/src/common.ts
+++ b/src/common.ts
@@ -359,6 +359,16 @@ export function defaultErrorRedactor<T = any>(data: {
       if (/^authentication$/.test(key)) {
         headers[key] = REDACT;
       }
+
+      // any casing of `Authorization`
+      if (/^authorization$/.test(key)) {
+        headers[key] = REDACT;
+      }
+
+      // anything containing secret, such as 'client secret'
+      if (/secret/.test(key)) {
+        headers[key] = REDACT;
+      }
     }
   }
 
@@ -370,7 +380,11 @@ export function defaultErrorRedactor<T = any>(data: {
     ) {
       const text = obj[key];
 
-      if (/grant_type=/.test(text) || /assertion=/.test(text)) {
+      if (
+        /grant_type=/.test(text) ||
+        /assertion=/.test(text) ||
+        /secret/.test(text)
+      ) {
         obj[key] = REDACT;
       }
     }
@@ -384,6 +398,10 @@ export function defaultErrorRedactor<T = any>(data: {
 
       if ('assertion' in obj) {
         obj['assertion'] = REDACT;
+      }
+
+      if ('client_secret' in obj) {
+        obj['client_secret'] = REDACT;
       }
     }
   }
@@ -402,6 +420,10 @@ export function defaultErrorRedactor<T = any>(data: {
 
       if (url.searchParams.has('token')) {
         url.searchParams.set('token', REDACT);
+      }
+
+      if (url.searchParams.has('client_secret')) {
+        url.searchParams.set('client_secret', REDACT);
       }
 
       data.config.url = url.toString();

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -704,11 +704,13 @@ describe('🎏 data handling', () => {
 
     const customURL = new URL(url);
     customURL.searchParams.append('token', 'sensitive');
+    customURL.searchParams.append('client_secret', 'data');
     customURL.searchParams.append('random', 'non-sensitive');
 
     const config: GaxiosOptions = {
       headers: {
         authentication: 'My Auth',
+        authorization: 'My Auth',
         'content-type': 'application/x-www-form-urlencoded',
         random: 'data',
       },
@@ -716,8 +718,9 @@ describe('🎏 data handling', () => {
         grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
         assertion: 'somesensitivedata',
         unrelated: 'data',
+        client_secret: 'data',
       },
-      body: 'grant_type=somesensitivedata&assertion=somesensitivedata',
+      body: 'grant_type=somesensitivedata&assertion=somesensitivedata&client_secret=data',
     };
 
     // simulate JSON response
@@ -756,6 +759,7 @@ describe('🎏 data handling', () => {
       assert.deepStrictEqual(e.config.headers, {
         ...config.headers, // non-redactables should be present
         authentication: REDACT,
+        authorization: REDACT,
       });
 
       // config redactions - data
@@ -763,6 +767,7 @@ describe('🎏 data handling', () => {
         ...config.data, // non-redactables should be present
         grant_type: REDACT,
         assertion: REDACT,
+        client_secret: REDACT,
       });
 
       // config redactions - body
@@ -773,6 +778,7 @@ describe('🎏 data handling', () => {
       const resultURL = new URL(e.config.url);
       assert.notDeepStrictEqual(resultURL.toString(), customURL.toString());
       customURL.searchParams.set('token', REDACT);
+      customURL.searchParams.set('client_secret', REDACT);
       assert.deepStrictEqual(resultURL.toString(), customURL.toString());
 
       // response redactions
@@ -781,11 +787,13 @@ describe('🎏 data handling', () => {
       assert.deepStrictEqual(e.response.headers, {
         ...responseHeaders, // non-redactables should be present
         authentication: REDACT,
+        authorization: REDACT,
       });
       assert.deepStrictEqual(e.response.data, {
         ...response, // non-redactables should be present
-        grant_type: REDACT,
         assertion: REDACT,
+        client_secret: REDACT,
+        grant_type: REDACT,
       });
     } finally {
       scope.done();


### PR DESCRIPTION
This `errorRedactor` is still considered **experimental** and is not a replacement for a DLP provider. For suggestions see:
- https://cloud.google.com/sensitive-data-protection/docs/redacting-sensitive-data#dlp_deidentify_replace_infotype-nodejs
- https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference#credentials_and_secrets

Fixes #604 🦕
