### PR TITLE
feat: Retry "408: Request Timeout" by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ interface GaxiosOptions = {
     httpMethodsToRetry?: string[];
 
     // The HTTP response status codes that will automatically be retried.
-    // Defaults to: [[100, 199], [429, 429], [500, 599]]
+    // Defaults to: [[100, 199], [408, 408], [429, 429], [500, 599]]
     statusCodesToRetry?: number[][];
 
     // Function to invoke when a retry attempt is made.

--- a/src/common.ts
+++ b/src/common.ts
@@ -304,7 +304,7 @@ export interface RetryConfig {
 
   /**
    * The HTTP response status codes that will automatically be retried.
-   * Defaults to: [[100, 199], [429, 429], [500, 599]]
+   * Defaults to: [[100, 199], [408, 408], [429, 429], [500, 599]]
    */
   statusCodesToRetry?: number[][];
 

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -42,9 +42,11 @@ export async function getRetryConfig(err: GaxiosError) {
     // 2xx - Do not retry (Success)
     // 3xx - Do not retry (Redirect)
     // 4xx - Do not retry (Client errors)
+    // 408 - Retry ("Request Timeout")
     // 429 - Retry ("Too Many Requests")
     // 5xx - Retry (Server errors)
     [100, 199],
+    [408, 408],
     [429, 429],
     [500, 599],
   ];

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -51,6 +51,7 @@ describe('🛸 retry & exponential backoff', () => {
       }
       const expectedStatusCodes = [
         [100, 199],
+        [408, 408],
         [429, 429],
         [500, 599],
       ];


### PR DESCRIPTION
This can be caused by a number of reasons, including a slow proxy. This is widely considered safe to retry.

Related:
- https://github.com/googleapis/google-auth-library-nodejs/issues/1366

🦕