### PR TITLE
feat!: `fetch` (POC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ interface GaxiosOptions = {
   headers: { 'some': 'header' },
 
   // The data to send in the body of the request. Data objects will be
-  // serialized as JSON.
+  // serialized as JSON, except for `FormData`.
   //
   // Note: if you would like to provide a Content-Type header other than
   // application/json you you must provide a string or readable stream, rather
@@ -151,8 +151,7 @@ interface GaxiosOptions = {
   // Enables default configuration for retries.
   retry: boolean,
 
-  // Cancelling a request requires the `abort-controller` library.
-  // See https://github.com/bitinn/node-fetch#request-cancellation-with-abortsignal
+  // Enables aborting via AbortController
   signal?: AbortSignal
 
   /**

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ interface GaxiosOptions = {
     httpMethodsToRetry?: string[];
 
     // The HTTP response status codes that will automatically be retried.
-    // Defaults to: [[100, 199], [429, 429], [500, 599]]
+    // Defaults to: [[100, 199], [408, 408], [429, 429], [500, 599]]
     statusCodesToRetry?: number[][];
 
     // Function to invoke when a retry attempt is made.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/googleapis/gaxios/branch/master/graph/badge.svg)](https://codecov.io/gh/googleapis/gaxios)
 [![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://github.com/google/gts)
 
-> An HTTP request client that provides an `axios` like interface over top of `node-fetch`.
+> An HTTP request client that provides an `axios` like interface over top of `fetch`.
 
 ## Install
 
@@ -71,10 +71,6 @@ interface GaxiosOptions = {
   // Defaults to `0`, which is the same as unset.
   maxContentLength: 2000,
 
-  // The max number of HTTP redirects to follow.
-  // Defaults to 100.
-  maxRedirects: 100,
-
   // The querystring parameters that will be encoded using `qs` and
   // appended to the url
   params: {
@@ -114,9 +110,9 @@ interface GaxiosOptions = {
   // status code.  Defaults to (>= 200 && < 300)
   validateStatus: (status: number) => true,
 
-  // Implementation of `fetch` to use when making the API call. By default,
-  // will use the browser context if available, and fall back to `node-fetch`
-  // in node.js otherwise.
+  /**
+   * Implementation of `fetch` to use when making the API call. Will use `fetch` by default.
+   */
   fetchImplementation?: typeof fetch;
 
   // Configuration for retrying of requests.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "multiparty": "^4.2.1",
     "mv": "^2.1.1",
     "ncp": "^2.0.0",
-    "nock": "^13.0.0",
+    "nock": "^14.0.0-beta.5",
     "null-loader": "^4.0.0",
     "puppeteer": "^21.0.0",
     "sinon": "^17.0.0",
@@ -85,8 +85,6 @@
   "dependencies": {
     "extend": "^3.0.2",
     "https-proxy-agent": "^7.0.1",
-    "is-stream": "^2.0.0",
-    "node-fetch": "^3.3.2",
     "uuid": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,18 +47,15 @@
     "@types/mv": "^2.1.0",
     "@types/ncp": "^2.0.1",
     "@types/node": "^20.0.0",
-    "@types/node-fetch": "^2.5.7",
     "@types/sinon": "^17.0.0",
     "@types/tmp": "0.2.6",
     "@types/uuid": "^9.0.0",
-    "abort-controller": "^3.0.0",
     "assert": "^2.0.0",
     "browserify": "^17.0.0",
     "c8": "^8.0.0",
     "cors": "^2.8.5",
     "execa": "^5.0.0",
     "express": "^4.16.4",
-    "form-data": "^4.0.0",
     "gts": "^5.0.0",
     "is-docker": "^2.0.0",
     "karma": "^6.0.0",
@@ -89,7 +86,7 @@
     "extend": "^3.0.2",
     "https-proxy-agent": "^7.0.1",
     "is-stream": "^2.0.0",
-    "node-fetch": "^2.6.9",
+    "node-fetch": "^3.3.2",
     "uuid": "^9.0.1"
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -203,9 +203,8 @@ export interface GaxiosOptions {
   validateStatus?: (status: number) => boolean;
   retryConfig?: RetryConfig;
   retry?: boolean;
-  // Should be instance of https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
-  // interface. Left as 'any' due to incompatibility between spec and abort-controller.
-  signal?: any;
+  // Enables aborting via AbortController
+  signal?: AbortSignal;
   size?: number;
   /**
    * Implementation of `fetch` to use when making the API call. By default,

--- a/src/common.ts
+++ b/src/common.ts
@@ -304,7 +304,7 @@ export interface RetryConfig {
 
   /**
    * The HTTP response status codes that will automatically be retried.
-   * Defaults to: [[100, 199], [429, 429], [500, 599]]
+   * Defaults to: [[100, 199], [408, 408], [429, 429], [500, 599]]
    */
   statusCodesToRetry?: number[][];
 

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -15,13 +15,9 @@ import extend from 'extend';
 import {Agent} from 'http';
 import {Agent as HTTPSAgent} from 'https';
 import qs from 'querystring';
-import isStream from 'is-stream';
 import {URL} from 'url';
 
-import type nodeFetch from 'node-fetch' with {'resolution-mode': 'import'};
-
 import {
-  FetchResponse,
   GaxiosMultipartOptions,
   GaxiosError,
   GaxiosOptions,
@@ -35,24 +31,6 @@ import {Readable} from 'stream';
 import {v4} from 'uuid';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-function hasBuffer() {
-  return typeof Buffer !== 'undefined';
-}
-
-function hasHeader(options: GaxiosOptions, header: string) {
-  return !!getHeader(options, header);
-}
-
-function getHeader(options: GaxiosOptions, header: string): string | undefined {
-  header = header.toLowerCase();
-  for (const key of Object.keys(options?.headers || {})) {
-    if (header === key.toLowerCase()) {
-      return options.headers![key];
-    }
-  }
-  return undefined;
-}
 
 export class Gaxios {
   protected agentCache = new Map<
@@ -78,23 +56,19 @@ export class Gaxios {
    * @param opts Set of HTTP options that will be used for this HTTP request.
    */
   async request<T = any>(opts: GaxiosOptions = {}): GaxiosPromise<T> {
-    opts = await this.#prepareRequest(opts);
-    return this._request(opts);
+    const prepared = await this.#prepareRequest(opts);
+    return this._request(prepared);
   }
 
   private async _defaultAdapter<T>(
-    opts: GaxiosOptions
+    config: GaxiosOptions
   ): Promise<GaxiosResponse<T>> {
-    const fetchImpl = opts.fetchImplementation || (await Gaxios.#getFetch());
+    const fetchImpl = config.fetchImplementation || fetch;
 
-    // node-fetch v3 warns when `data` is present
-    // https://github.com/node-fetch/node-fetch/issues/1000
-    const preparedOpts = {...opts};
-    delete preparedOpts.data;
+    const res = await fetchImpl(config.url!, config);
+    const data = await this.getResponseData(config, res);
 
-    const res = await fetchImpl(opts.url, preparedOpts);
-    const data = await this.getResponseData(opts, res);
-    return this.translateResponse<T>(opts, res, data);
+    return Object.assign(res, {config, data}) as GaxiosResponse<T>;
   }
 
   /**
@@ -117,13 +91,12 @@ export class Gaxios {
 
       if (!opts.validateStatus!(translatedResponse.status)) {
         if (opts.responseType === 'stream') {
-          let response = '';
-          await new Promise(resolve => {
-            (translatedResponse?.data as Readable).on('data', chunk => {
-              response += chunk;
-            });
-            (translatedResponse?.data as Readable).on('end', resolve);
-          });
+          const response = [];
+
+          for await (const chunk of opts.data) {
+            response.push(chunk);
+          }
+
           translatedResponse.data = response as T;
         }
         throw new GaxiosError<T>(
@@ -156,18 +129,26 @@ export class Gaxios {
 
   private async getResponseData(
     opts: GaxiosOptions,
-    res: FetchResponse
+    res: Response
   ): Promise<any> {
+    if (
+      opts.maxContentLength &&
+      res.headers.has('content-length') &&
+      opts.maxContentLength <
+        Number.parseInt(res.headers?.get('content-length') || '')
+    ) {
+      throw new GaxiosError(
+        "Response's `Content-Length` is over the limit.",
+        opts,
+        Object.assign(res, {config: opts, data: null}) as GaxiosResponse
+      );
+    }
+
     switch (opts.responseType) {
       case 'stream':
         return res.body;
       case 'json':
-        try {
-          return await res.json();
-        } catch {
-          // fallback to returning text
-          return await res.text();
-        }
+        return res.json();
       case 'arraybuffer':
         return res.arrayBuffer();
       case 'blob':
@@ -253,45 +234,39 @@ export class Gaxios {
       opts.url = opts.url + prefix + additionalQueryParams;
     }
 
-    if (typeof options.maxContentLength === 'number') {
-      opts.size = options.maxContentLength;
-    }
+    const preparedHeaders =
+      opts.headers instanceof Headers
+        ? opts.headers
+        : new Headers(opts.headers);
 
-    if (typeof options.maxRedirects === 'number') {
-      opts.follow = options.maxRedirects;
-    }
-
-    opts.headers = opts.headers || {};
-
-    // FormData is available in Node.js versions 18.0.0+, however there is a runtime
-    // warning until 18.13.0. Additionally, `node-fetch` v3 only supports the official
-    // `FormData` or its own exported `FormData` class:
-    // - https://nodejs.org/api/globals.html#class-formdata
-    // - https://nodejs.org/en/blog/release/v18.13.0
-    // - https://github.com/node-fetch/node-fetch/issues/1167
-    // const isFormData = opts?.data instanceof FormData;
-    const isFormData = opts.data?.constructor?.name === 'FormData';
+    const isFormData = opts?.data instanceof FormData;
 
     if (opts.multipart === undefined && opts.data) {
-      if (isStream.readable(opts.data)) {
-        opts.body = opts.data;
-      } else if (hasBuffer() && Buffer.isBuffer(opts.data)) {
+      if (
+        opts.data instanceof ReadableStream ||
+        opts.data instanceof Readable
+      ) {
+        opts.body = opts.data as ReadableStream;
+      } else if (
+        opts.data instanceof Blob ||
+        ('Buffer' in globalThis && Buffer.isBuffer(opts.data))
+      ) {
         // Do not attempt to JSON.stringify() a Buffer:
         opts.body = opts.data;
-        if (!hasHeader(opts, 'Content-Type')) {
-          opts.headers['Content-Type'] = 'application/json';
+        if (!preparedHeaders.has('content-type')) {
+          preparedHeaders.set('content-type', 'application/json');
         }
       } else if (typeof opts.data === 'object' && !isFormData) {
         if (
-          getHeader(opts, 'content-type') ===
+          preparedHeaders.get('Content-Type') ===
           'application/x-www-form-urlencoded'
         ) {
           // If www-form-urlencoded content type has been set, but data is
           // provided as an object, serialize the content
           opts.body = opts.paramsSerializer(opts.data);
         } else {
-          if (!hasHeader(opts, 'Content-Type')) {
-            opts.headers['Content-Type'] = 'application/json';
+          if (!preparedHeaders.has('content-type')) {
+            preparedHeaders.set('content-type', 'application/json');
           }
           opts.body = JSON.stringify(opts.data);
         }
@@ -303,16 +278,20 @@ export class Gaxios {
       // this can be replaced with randomUUID() function from crypto
       // and the dependency on UUID removed
       const boundary = v4();
-      opts.headers['Content-Type'] = `multipart/related; boundary=${boundary}`;
+      preparedHeaders.set(
+        'content-type',
+        `multipart/related; boundary=${boundary}`
+      );
+
       opts.body = Readable.from(
         this.getMultipartRequest(opts.multipart, boundary)
-      );
+      ) as {} as ReadableStream;
     }
 
     opts.validateStatus = opts.validateStatus || this.validateStatus;
     opts.responseType = opts.responseType || 'unknown';
-    if (!opts.headers['Accept'] && opts.responseType === 'json') {
-      opts.headers['Accept'] = 'application/json';
+    if (!preparedHeaders.has('accept') && opts.responseType === 'json') {
+      preparedHeaders.set('accept', 'application/json');
     }
     opts.method = opts.method || 'GET';
 
@@ -359,7 +338,27 @@ export class Gaxios {
       opts.errorRedactor = defaultErrorRedactor;
     }
 
-    return opts;
+    if (opts.body && !('duplex' in opts)) {
+      /**
+       * required for Node.js and the type isn't available today
+       * @link https://github.com/nodejs/node/issues/46221
+       * @link https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1483
+       */
+      (opts as {duplex: string}).duplex = 'half';
+    }
+
+    // preserve the original type for auditing later
+    if (opts.headers instanceof Headers) {
+      opts.headers = preparedHeaders;
+    } else {
+      const headers: Headers = {};
+      preparedHeaders.forEach((value, key) => {
+        headers[key] = value;
+      });
+      opts.headers = headers;
+    }
+
+    return {...opts};
   }
 
   /**
@@ -378,38 +377,13 @@ export class Gaxios {
     return qs.stringify(params);
   }
 
-  private translateResponse<T>(
-    opts: GaxiosOptions,
-    res: FetchResponse,
-    data?: T
-  ): GaxiosResponse<T> {
-    // headers need to be converted from a map to an obj
-    const headers = {} as Headers;
-    res.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
-
-    return {
-      config: opts,
-      data: data as T,
-      headers,
-      status: res.status,
-      statusText: res.statusText,
-
-      // XMLHttpRequestLike
-      request: {
-        responseURL: res.url,
-      },
-    };
-  }
-
   /**
    * Attempts to parse a response by looking at the Content-Type header.
-   * @param {FetchResponse} response the HTTP response.
+   * @param {Response} response the HTTP response.
    * @returns {Promise<any>} a promise that resolves to the response data.
    */
   private async getResponseDataFromContentType(
-    response: FetchResponse
+    response: Response
   ): Promise<any> {
     let contentType = response.headers.get('Content-Type');
     if (contentType === null) {
@@ -470,14 +444,6 @@ export class Gaxios {
   static #proxyAgent?: typeof import('https-proxy-agent').HttpsProxyAgent;
 
   /**
-   * A cache for the lazily-loaded fetch library.
-   *
-   * Should use {@link Gaxios[#getFetch]} to retrieve.
-   */
-  //
-  static #fetch?: typeof nodeFetch | typeof fetch;
-
-  /**
    * Imports, caches, and returns a proxy agent - if not already imported
    *
    * @returns A proxy agent
@@ -486,15 +452,5 @@ export class Gaxios {
     this.#proxyAgent ||= (await import('https-proxy-agent')).HttpsProxyAgent;
 
     return this.#proxyAgent;
-  }
-
-  static async #getFetch() {
-    const hasWindow = typeof window !== 'undefined' && !!window;
-
-    this.#fetch ||= hasWindow
-      ? window.fetch
-      : (await import('node-fetch')).default;
-
-    return this.#fetch;
   }
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -68,7 +68,7 @@ export async function getRetryConfig(err: GaxiosError) {
   const delay =
     retryDelay + ((Math.pow(2, config.currentRetryAttempt) - 1) / 2) * 1000;
 
-  // We're going to retry!  Incremenent the counter.
+  // We're going to retry!  Increment the counter.
   err.config.retryConfig!.currentRetryAttempt! += 1;
 
   // Create a promise that invokes the retry after the backOffDelay

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -95,9 +95,13 @@ export async function getRetryConfig(err: GaxiosError) {
 function shouldRetryRequest(err: GaxiosError) {
   const config = getConfig(err);
 
-  // node-fetch raises an AbortError if signaled:
-  // https://github.com/bitinn/node-fetch#request-cancellation-with-abortsignal
-  if (err.name === 'AbortError' || err.error?.name === 'AbortError') {
+  // `fetch` raises an AbortError if signaled:
+  // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+  if (
+    err.config.signal?.aborted ||
+    err.name === 'AbortError' ||
+    err.error?.name === 'AbortError'
+  ) {
     return false;
   }
 

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -42,9 +42,11 @@ export async function getRetryConfig(err: GaxiosError) {
     // 2xx - Do not retry (Success)
     // 3xx - Do not retry (Redirect)
     // 4xx - Do not retry (Client errors)
+    // 408 - Retry ("Request Timeout")
     // 429 - Retry ("Too Many Requests")
     // 5xx - Retry (Server errors)
     [100, 199],
+    [408, 408],
     [429, 429],
     [500, 599],
   ];

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -601,7 +601,8 @@ describe('🥁 configuration options', () => {
   });
 
   it('should not stringify the data if it is appended by a form', async () => {
-    const FormData = (await import('node-fetch')).FormData;
+    // Optional, can use `node-fetch`'s FormData to avoid warnings in Node < 18.13
+    // const FormData = (await import('node-fetch')).FormData;
     const formData = new FormData();
     formData.append('test', '123');
 

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AbortController} from 'abort-controller';
 import assert from 'assert';
 import nock from 'nock';
 import {describe, it, afterEach} from 'mocha';

--- a/test/test.retry.ts
+++ b/test/test.retry.ts
@@ -51,6 +51,7 @@ describe('🛸 retry & exponential backoff', () => {
       }
       const expectedStatusCodes = [
         [100, 199],
+        [408, 408],
         [429, 429],
         [500, 599],
       ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
-    "lib": ["es2015", "dom"],
+    "lib": ["es2020", "dom"],
     "rootDir": ".",
     "outDir": "build",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "module": "Node16",
+    "moduleResolution": "Node16",
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
A proof-of-concept for migrating to native `fetch`. However, there are a few limitations today.

## No native proxy support

It is possible to enable proxy support, however customers would have to install `unidici` downstream. Including it in this library would make it far too large. Here are some numbers:

| package                               | version | size (minified) |
| -------------------------- | -------- | -------------- |
| `gaxios`                               | 6.5.0     | [38.3 kB](https://bundlephobia.com/package/gaxios@6.5.0)  |
| `undici`                                | 6.5.0     | [402.6 kB](https://bundlephobia.com/package/undici@6.5.0)  |
| `@google-cloud/storage`  | 7.10.0    | [484.2 kB](https://bundlephobia.com/package/@google-cloud/storage@7.10.0) |

Adding `undici` would in **double** the size of a downstream dependency like `@google-cloud/storage`.

However, there is chatter on adding the `ProxyAgent` within Node:
- https://github.com/nodejs/node/issues/43187

Additionally, it wasn't until recently that `undici` added env support for `HTTP_PROXY`, `HTTPS_PROXY`, & `NO_PROXY` and it will take time for it to propagate to Node.js releases:
- https://github.com/nodejs/undici/pull/2994

## Performance

The native `fetch` implementation is 26% - 28% slower than `node-fetch` according to `undici`'s benchmarks:
- https://github.com/nodejs/undici?tab=readme-ov-file#benchmarks

## Returning Streams

Native `fetch` returns a ReadableStream (Web Streams) instead of stream.Readable. This may require a rewriting downstream for many applications that currently return a stream.

However, here's a simple way to resolve:

```ts
import {Readable} from 'node:stream';

Readable.fromWeb(res.body);
```

🦕
