### PR TITLE
chore: minor TS Config clean-up

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,8 +1,7 @@
 {
   "extends": "gts/tsconfig-google.json",
   "compilerOptions": {
-    "lib": ["es2020", "dom"],
-    "esModuleInterop": true,
+    "lib": ["ES2023", "dom"],
     "rootDir": "."
   },
   "include": ["src/*.*ts", "test/*.ts", "browser-test/*.ts", "system-test/*.ts"]


### PR DESCRIPTION
Clean-up ensuring stricter type-checking by removing `esModuleInterop: true`

Background: https://www.typescriptlang.org/docs/handbook/modules/appendices/esm-cjs-interop.html

🦕
