### PR TITLE
feat: `fetch`-Compatible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ import {request} from 'gaxios';
 const res = await request({url: 'https://google.com/'});
 ```
 
+## `fetch`-Compatible API Example
+
+We offer a drop-in `fetch`-compatible API as well.
+
+```js
+import {instance} from 'gaxios';
+const res = await instance.fetch('https://google.com/');
+```
+
 ## Setting Defaults
 
 Gaxios supports setting default properties both on the default instance, and on additional instances. This is often useful when making many requests to the same domain with the same base settings. For example:

--- a/src/common.ts
+++ b/src/common.ts
@@ -278,10 +278,6 @@ export interface GaxiosOptions extends RequestInit {
   retryConfig?: RetryConfig;
   retry?: boolean;
   /**
-   * Enables aborting via {@link AbortController}.
-   */
-  signal?: AbortSignal;
-  /**
    * @deprecated non-spec. https://github.com/node-fetch/node-fetch/issues/1438
    */
   size?: number;

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -740,7 +740,7 @@ describe('🥁 configuration options', () => {
 });
 
 describe('🎏 data handling', () => {
-  it('should accpet a ReadableStream as request data', async () => {
+  it('should accept a ReadableStream as request data', async () => {
     const scope = nock(url).post('/', 'test').reply(200, {});
     const res = await request({
       url,
@@ -1452,5 +1452,62 @@ describe('interceptors', () => {
       await instance.request({url});
       scope.done();
     });
+  });
+});
+
+/**
+ * Fetch-compliant API testing.
+ *
+ * Documentation:
+ * - https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+ * - https://nodejs.org/docs/latest/api/globals.html#fetch
+ */
+describe('fetch-compatible API', () => {
+  it('should accept a `string`', async () => {
+    const scope = nock(url).get('/').reply(200, {});
+
+    const gaxios = new Gaxios();
+    const res = await gaxios.fetch(url);
+
+    scope.done();
+    assert(typeof url === 'string');
+    assert.deepStrictEqual(res.data, {});
+  });
+
+  it('should accept a `URL`', async () => {
+    const scope = nock(url).get('/').reply(200, {});
+
+    const gaxios = new Gaxios();
+    const res = await gaxios.fetch(new URL(url));
+
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
+  });
+
+  it('should accept an input with initialization', async () => {
+    const scope = nock(url).post('/', 'abc').reply(200, {});
+
+    const gaxios = new Gaxios();
+    const res = await gaxios.fetch(url, {
+      body: Buffer.from('abc'),
+      method: 'POST',
+    });
+
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
+  });
+
+  it('should accept `GaxiosOptions`', async () => {
+    const scope = nock(url).post('/', 'abc').reply(200, {});
+
+    const gaxios = new Gaxios();
+    const options: GaxiosOptions = {
+      body: Buffer.from('abc'),
+      method: 'POST',
+    };
+    const res = await gaxios.fetch(url, options);
+
+    scope.done();
+    assert.deepStrictEqual(res.data, {});
   });
 });


### PR DESCRIPTION
This will greatly improve ergonomics for customers and our downstream libraries. Notably:
- `Gaxios` can be a drop-in replacement for libraries requiring `fetch`-API compliance
- By offering a `fetch`-compliant API in `Gaxios` we can utilize it within our own libraries, such as `google-auth-library`, and in turn expose a `fetch`-compatible API for customers downstream
  - Additionally, this would allow `google-auth-library` to streamline request handling by removing the [`Transporter`](https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/transporters.ts) concept altogether.

Here's an example for customers wanting this functionality:
- https://www.youtube.com/watch?v=IY-z00bfnOc&t=291s (from  4:51-5:10)


🦕
