### PR TITLE
refactor: Remove Duplicate `signal` from `GaxiosOptions` Interface

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -278,10 +278,6 @@ export interface GaxiosOptions extends RequestInit {
   retryConfig?: RetryConfig;
   retry?: boolean;
   /**
-   * Enables aborting via {@link AbortController}.
-   */
-  signal?: AbortSignal;
-  /**
    * @deprecated non-spec. https://github.com/node-fetch/node-fetch/issues/1438
    */
   size?: number;


### PR DESCRIPTION
This interface extends from `RequestInit`, which already has this property and documentation.

🦕
