### PR TITLE
revert: Undeprecate `adapter`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -162,8 +162,6 @@ export interface GaxiosOptions extends RequestInit {
   /**
    * Optional method to override making the actual HTTP request. Useful
    * for writing tests.
-   *
-   * @deprecated Use {@link GaxiosOptions.fetchImplementation} instead.
    */
   adapter?: <T = GaxiosResponseData>(
     options: GaxiosOptionsPrepared,


### PR DESCRIPTION
It's a convenient method for customers to debug and prototype. Other methods require more work and complexity for tasks like:
- passthrough body support
- disabling/inspecting the body before/after transformations

🦕