### PR TITLE
feat: Open Utility for Merging Headers

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -668,3 +668,5 @@ export class Gaxios implements FetchCompliance {
     return base;
   }
 }
+
+type HeadersInit = ConstructorParameters<typeof Headers>[0];

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -655,15 +655,18 @@ export class Gaxios implements FetchCompliance {
    * @param append headers to append/overwrite with
    * @returns the base headers instance with merged `Headers`
    */
-  static mergeHeaders(base: HeadersInit, append?: HeadersInit): Headers {
+  static mergeHeaders(base: HeadersInit, ...append: HeadersInit[]): Headers {
     base = base instanceof Headers ? base : new Headers(base);
-    append = append instanceof Headers ? append : new Headers(append);
 
-    append.forEach((value, key) => {
-      // set-cookie is the only header that would repeat.
-      // A bit of background: https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie
-      key === 'set-cookie' ? base.append(key, value) : base.set(key, value);
-    });
+    for (const headers of append) {
+      const add = headers instanceof Headers ? headers : new Headers(headers);
+
+      add.forEach((value, key) => {
+        // set-cookie is the only header that would repeat.
+        // A bit of background: https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie
+        key === 'set-cookie' ? base.append(key, value) : base.set(key, value);
+      });
+    }
 
     return base;
   }

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -115,10 +115,10 @@ export class Gaxios implements FetchCompliance {
 
     // prepare headers
     if (input && typeof input === 'object' && 'headers' in input) {
-      this.#mergeHeaders(headers, input.headers);
+      Gaxios.mergeHeaders(headers, input.headers);
     }
     if (init) {
-      this.#mergeHeaders(headers, new Headers(init.headers));
+      Gaxios.mergeHeaders(headers, new Headers(init.headers));
     }
 
     // prepare request
@@ -363,23 +363,6 @@ export class Gaxios implements FetchCompliance {
   }
 
   /**
-   * Merges headers.
-   *
-   * @param base headers to append/overwrite to
-   * @param append headers to append/overwrite with
-   * @returns the base headers instance with merged `Headers`
-   */
-  #mergeHeaders(base: Headers, append?: Headers) {
-    append?.forEach((value, key) => {
-      // set-cookie is the only header that would repeat.
-      // A bit of background: https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie
-      key === 'set-cookie' ? base.append(key, value) : base.set(key, value);
-    });
-
-    return base;
-  }
-
-  /**
    * Validates the options, merges them with defaults, and prepare request.
    *
    * @param options The original options passed from the client.
@@ -390,7 +373,7 @@ export class Gaxios implements FetchCompliance {
   ): Promise<GaxiosOptionsPrepared> {
     // Prepare Headers - copy in order to not mutate the original objects
     const preparedHeaders = new Headers(this.defaults.headers);
-    this.#mergeHeaders(preparedHeaders, options.headers);
+    Gaxios.mergeHeaders(preparedHeaders, options.headers);
 
     // Merge options
     const opts = extend(true, {}, this.defaults, options);
@@ -663,5 +646,25 @@ export class Gaxios implements FetchCompliance {
       : (await import('node-fetch')).default;
 
     return this.#fetch;
+  }
+
+  /**
+   * Merges headers.
+   *
+   * @param base headers to append/overwrite to
+   * @param append headers to append/overwrite with
+   * @returns the base headers instance with merged `Headers`
+   */
+  static mergeHeaders(base: HeadersInit, append?: HeadersInit): Headers {
+    base = base instanceof Headers ? base : new Headers(base);
+    append = append instanceof Headers ? append : new Headers(append);
+
+    append.forEach((value, key) => {
+      // set-cookie is the only header that would repeat.
+      // A bit of background: https://developer.mozilla.org/en-US/docs/Web/API/Headers/getSetCookie
+      key === 'set-cookie' ? base.append(key, value) : base.set(key, value);
+    });
+
+    return base;
   }
 }

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -650,12 +650,20 @@ export class Gaxios implements FetchCompliance {
 
   /**
    * Merges headers.
+   * If the base headers do not exist a new `Headers` object will be returned.
+   *
+   * @remarks
+   *
+   * Using this utility can be helpful when the headers are not known to exist:
+   * - if they exist as `Headers`, that instance will be used
+   * - if they exist in another form, they will be used as a new Headers object
+   * - if they do not exist
    *
    * @param base headers to append/overwrite to
    * @param append headers to append/overwrite with
    * @returns the base headers instance with merged `Headers`
    */
-  static mergeHeaders(base: HeadersInit, ...append: HeadersInit[]): Headers {
+  static mergeHeaders(base?: HeadersInit, ...append: HeadersInit[]): Headers {
     base = base instanceof Headers ? base : new Headers(base);
 
     for (const headers of append) {

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -656,8 +656,9 @@ export class Gaxios implements FetchCompliance {
    *
    * Using this utility can be helpful when the headers are not known to exist:
    * - if they exist as `Headers`, that instance will be used
-   * - if they exist in another form, they will be used as a new Headers object
-   * - if they do not exist
+   *   - it improves performance and allows users to use their existing references to their `Headers`
+   * - if they exist in another form (`HeadersInit`), they will be used to create a new `Headers` object
+   * - if the base headers do not exist a new `Headers` object will be created
    *
    * @param base headers to append/overwrite to
    * @param append headers to append/overwrite with

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -1539,13 +1539,16 @@ describe('merge headers', () => {
     }
   });
 
-  it('should merge set-cookie headers', () => {
+  it.only('should merge set-cookie headers', () => {
     const base = {'set-cookie': 'a=a'};
     const append = {'set-cookie': 'b=b'};
-    const expected = new Headers({'set-cookie': 'a=a, b=b'});
+    const expected = new Headers([
+      ['set-cookie', 'a=a'],
+      ['set-cookie', 'b=b'],
+    ]);
 
     const headers = Gaxios.mergeHeaders(base, append);
 
-    assert.deepStrictEqual(headers, expected);
+    assert.deepStrictEqual(headers.getSetCookie(), expected.getSetCookie());
   });
 });

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -1518,13 +1518,8 @@ describe('merge headers', () => {
     const append = {b: 'b'};
     const expected = new Headers({...base, ...append});
 
-    const matrixBase: HeadersInit[] = [
-      {...base},
-      Object.entries(base),
-      new Headers(base),
-    ];
-
-    const matrixAppend: HeadersInit[] = [
+    const matrixBase = [{...base}, Object.entries(base), new Headers(base)];
+    const matrixAppend = [
       {...append},
       Object.entries(append),
       new Headers(append),

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -1539,7 +1539,7 @@ describe('merge headers', () => {
     }
   });
 
-  it.only('should merge set-cookie headers', () => {
+  it('should merge set-cookie headers', () => {
     const base = {'set-cookie': 'a=a'};
     const append = {'set-cookie': 'b=b'};
     const expected = new Headers([

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -1511,3 +1511,41 @@ describe('fetch-compatible API', () => {
     assert.deepStrictEqual(res.data, {});
   });
 });
+
+describe('merge headers', () => {
+  it('should merge headers', () => {
+    const base = {a: 'a'};
+    const append = {b: 'b'};
+    const expected = new Headers({...base, ...append});
+
+    const matrixBase: HeadersInit[] = [
+      {...base},
+      Object.entries(base),
+      new Headers(base),
+    ];
+
+    const matrixAppend: HeadersInit[] = [
+      {...append},
+      Object.entries(append),
+      new Headers(append),
+    ];
+
+    for (const base of matrixBase) {
+      for (const append of matrixAppend) {
+        const headers = Gaxios.mergeHeaders(base, append);
+
+        assert.deepStrictEqual(headers, expected);
+      }
+    }
+  });
+
+  it('should merge set-cookie headers', () => {
+    const base = {'set-cookie': 'a=a'};
+    const append = {'set-cookie': 'b=b'};
+    const expected = new Headers({'set-cookie': 'a=a, b=b'});
+
+    const headers = Gaxios.mergeHeaders(base, append);
+
+    assert.deepStrictEqual(headers, expected);
+  });
+});

--- a/test/test.getch.ts
+++ b/test/test.getch.ts
@@ -1513,7 +1513,7 @@ describe('fetch-compatible API', () => {
 });
 
 describe('merge headers', () => {
-  it('should merge headers', () => {
+  it('should merge Headers', () => {
     const base = {a: 'a'};
     const append = {b: 'b'};
     const expected = new Headers({...base, ...append});
@@ -1534,7 +1534,18 @@ describe('merge headers', () => {
     }
   });
 
-  it('should merge set-cookie headers', () => {
+  it('should merge multiple Headers', () => {
+    const base = {a: 'a'};
+    const append = {b: 'b'};
+    const appendMore = {c: 'c'};
+    const expected = new Headers({...base, ...append, ...appendMore});
+
+    const headers = Gaxios.mergeHeaders(base, append, appendMore);
+
+    assert.deepStrictEqual(headers, expected);
+  });
+
+  it('should merge Set-Cookie Headers', () => {
     const base = {'set-cookie': 'a=a'};
     const append = {'set-cookie': 'b=b'};
     const expected = new Headers([


### PR DESCRIPTION
## Description

Opens up a simple utility for merging different types of headers.

## Testing

Added tests.

## Impact

Opening this utility can be helpful when the headers are not known to exist:
- if they exist as `Headers`, that instance will be used
  - Improves UX as it improves performance and allows customers to use their existing references to their Headers
- if they exist in another form (`HeadersInit`), they will be used to create a new `Headers` object
- if the base headers do not exist a new `Headers` object will be created

🦕
