### PR TITLE
fix: Redact After Retry Attempts

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -129,13 +129,6 @@ export class GaxiosError<T = any> extends Error {
     if (error && 'code' in error && error.code) {
       this.code = error.code;
     }
-
-    if (config.errorRedactor) {
-      config.errorRedactor({
-        config: this.config,
-        response: this.response,
-      });
-    }
   }
 }
 
@@ -496,7 +489,7 @@ export function defaultErrorRedactor<
   }
 
   function redactObject<T extends O['data'] | R>(obj: T | null) {
-    if (!obj) {
+    if (!obj || typeof obj !== 'object') {
       return;
     } else if (
       obj instanceof FormData ||

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -229,6 +229,10 @@ export class Gaxios implements FetchCompliance {
         return this._request<T>(opts);
       }
 
+      if (opts.errorRedactor) {
+        opts.errorRedactor(err);
+      }
+
       throw err;
     }
   }


### PR DESCRIPTION
## Description

The expiremental error redactor redacts before retry attempts are made. This can be a hassle for customers. In the event of a retry we should use the unredacted data without any injections.

## Testing

Added tests.

## Impact

Less work for customers wanting both retries and error redaction.

🦕
