### PR TITLE
feat!: Support AIP-193 for `GaxiosError`

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -14,7 +14,7 @@
         "js-yaml": "^4.1.0"
     },
     "devDependencies": {
-        "@octokit/rest": "^19.0.0",
+        "@octokit/rest": "^21.0.0",
         "mocha": "^10.0.0",
         "sinon": "^18.0.0"
     }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -14,7 +14,7 @@
         "js-yaml": "^4.1.0"
     },
     "devDependencies": {
-        "@octokit/rest": "^21.0.0",
+        "@octokit/rest": "^19.0.0",
         "mocha": "^10.0.0",
         "sinon": "^18.0.0"
     }

--- a/README.md
+++ b/README.md
@@ -237,4 +237,4 @@ interface GaxiosOptions = {
 
 ## License
 
-[Apache-2.0](https://github.com/googleapis/gaxios/blob/master/LICENSE)
+[Apache-2.0](https://github.com/googleapis/gaxios/blob/main/LICENSE)

--- a/src/common.ts
+++ b/src/common.ts
@@ -196,7 +196,9 @@ export class GaxiosError<T = any> extends Error {
     defaultErrorMessage = 'The request failed',
   ): AIPErrorInterface['error'] {
     let message = defaultErrorMessage;
-
+if (typeof res.data === 'string') {
+    message = res.data;
+}
     if (
       res.data &&
       typeof res.data === 'object' &&

--- a/src/common.ts
+++ b/src/common.ts
@@ -62,16 +62,22 @@ export class GaxiosError<T = any> extends Error {
    * An error code.
    * Can be a system error code, DOMException error name, or any error's 'code' property where it is a `string`.
    *
+   * It is only a `number` when the cause is sourced from an API-level error (AIP-193).
+   *
    * @see {@link https://nodejs.org/api/errors.html#errorcode error.code}
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names DOMException#error_names}
+   * @see {@link https://google.aip.dev/193#http11json-representation AIP-193}
    *
    * @example
    * 'ECONNRESET'
    *
    * @example
    * 'TimeoutError'
+   *
+   * @example
+   * 500
    */
-  code?: string;
+  code?: string | number;
   /**
    * An HTTP Status code.
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response/status Response#status}
@@ -168,7 +174,7 @@ export class GaxiosError<T = any> extends Error {
       cause &&
       typeof cause === 'object' &&
       'code' in cause &&
-      typeof cause.code === 'string'
+      (typeof cause.code === 'string' || typeof cause.code === 'number')
     ) {
       this.code = cause.code;
     }

--- a/src/common.ts
+++ b/src/common.ts
@@ -196,9 +196,12 @@ export class GaxiosError<T = any> extends Error {
     defaultErrorMessage = 'The request failed',
   ): AIPErrorInterface['error'] {
     let message = defaultErrorMessage;
-if (typeof res.data === 'string') {
-    message = res.data;
-}
+
+    // Use res.data as the error message
+    if (typeof res.data === 'string') {
+      message = res.data;
+    }
+
     if (
       res.data &&
       typeof res.data === 'object' &&

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -201,18 +201,30 @@ export class Gaxios implements FetchCompliance {
 
           translatedResponse.data = response as T;
         }
-        throw new GaxiosError<T>(
+
+        const errorInfo = GaxiosError.extractAPIErrorFromResponse(
+          translatedResponse,
           `Request failed with status code ${translatedResponse.status}`,
+        );
+
+        throw new GaxiosError<T>(
+          errorInfo?.message,
           opts,
           translatedResponse,
+          errorInfo,
         );
       }
       return translatedResponse;
     } catch (e) {
-      const err =
-        e instanceof GaxiosError
-          ? e
-          : new GaxiosError((e as Error).message, opts, undefined, e as Error);
+      let err: GaxiosError;
+
+      if (e instanceof GaxiosError) {
+        err = e;
+      } else if (e instanceof Error) {
+        err = new GaxiosError(e.message, opts, undefined, e);
+      } else {
+        err = new GaxiosError('Unexpected Gaxios Error', opts, undefined, e);
+      }
 
       const {shouldRetry, config} = await getRetryConfig(err);
       if (shouldRetry && config) {

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -103,9 +103,8 @@ function shouldRetryRequest(err: GaxiosError) {
   const config = getConfig(err);
 
   if (
-    (err.config.signal?.aborted && err.error?.name !== 'TimeoutError') ||
-    err.name === 'AbortError' ||
-    err.error?.name === 'AbortError'
+    (err.config.signal?.aborted && err.code !== 'TimeoutError') ||
+    err.code === 'AbortError'
   ) {
     return false;
   }


### PR DESCRIPTION
## Description

Adds [AIP-193](https://google.aip.dev/193#http11json-representation) recommendations to `GaxiosError`, including:
- Surfacing API error messages as its message ([`Error.message`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message))
- Adding the content of the API error into Gaxios's cause property, which has first-class logging support in many environments ([`Error.cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause))

### History

Previously, some of this functionality was in `google-auth-library` within its now-removed transporter. It was within the transporter this logic predates this library itself (we were using request and axios at the time) and auth was the closest place to put such logic. This logic can now live where it belongs - gaxios.

Some additional references for background:
- https://github.com/googleapis/google-auth-library-nodejs/pull/1937
  - See `src/transporters.ts`
- https://github.com/googleapis/google-auth-library-nodejs/blob/14009b9fedb6c3fa755e4133640a39c3209fae19/lib/transporters.js
  - A historical example of the AIP's usage in `wrapCallback_` pre-gaxios
- https://github.com/googleapis/google-auth-library-nodejs/pull/1592
  - Added additional status/code support for the returned errors


## Impact

This will improve the debugging experience for customers as the API-level error is easy to see while the GaxiosError context/details are preserved.

## Testing

Updated tests to reflect. Note: many tests did not require changing as it is mostly backwards-compatible.

## Additional Information

- [AIP-193](https://google.aip.dev/193#http11json-representation)
- [Error#cause](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)

Fixes #572
Fixes #684

🦕
