### PR TITLE
fix: don't iterate over undefined opts.data.

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -196,7 +196,7 @@ export class Gaxios implements FetchCompliance {
         if (opts.responseType === 'stream') {
           const response = [];
 
-          for await (const chunk of opts.data as Readable) {
+          for await (const chunk of (opts.data ?? []) as Readable) {
             response.push(chunk);
           }
 


### PR DESCRIPTION
> Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

## Description

I was getting a "Cannot read properties of undefined" error from gaxios code instead of the actual error i was supposed to get.

```
error: TypeError: Cannot read properties of undefined (reading 'Symbol(Symbol.asyncIterator)')
      at Gaxios._request (/Volumes/Development/projects/happi/online_quiz/node_modules/gaxios/build/cjs/src/gaxios.js:148:52)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async GoogleDrive.getFileStream (/Volumes/Development/projects/happi/online_quiz/build/server/lib/cloud/googleDrive.js:305:27)
      at async getFileStream (/Volumes/Development/projects/happi/online_quiz/build/server/backoffice/routes.js:181:13)
      at async /Volumes/Development/projects/happi/online_quiz/build/server/backoffice/routes.js:239:21
      at async ifLoggedIn (/Volumes/Development/projects/happi/online_quiz/build/server/backoffice/routes.js:33:4),
  [Symbol(gaxios-gaxios-error)]: '7.1.0',
  [cause]: TypeError: Cannot read properties of undefined (reading 'Symbol(Symbol.asyncIterator)')
      at Gaxios._request (/Volumes/Development/projects/happi/online_quiz/node_modules/gaxios/build/cjs/src/gaxios.js:148:52)
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async GoogleDrive.getFileStream (/Volumes/Development/projects/happi/online_quiz/build/server/lib/cloud/googleDrive.js:305:27)
      at async getFileStream (/Volumes/Development/projects/happi/online_quiz/build/server/backoffice/routes.js:181:13)
      at async /Volumes/Development/projects/happi/online_quiz/build/server/backoffice/routes.js:239:21
      at async ifLoggedIn (/Volumes/Development/projects/happi/online_quiz/build/server/backoffice/routes.js:33:4)
```

I tracked it down to a loop over an undefined value and i just added a fallback to an empty array.
With that change i got the proper error i was supposed to get.

> Please provide a detailed description for the change.
> As much as possible, please try to keep changes separate by purpose. For example, try not to make a one-line bug fix in a feature request, or add an irrelevant README change to a bug fix.

## Impact

> What's the impact of this change?

No more nondescript error from the gaxios module but the proper result of the request.

## Testing

> Have you added unit and integration tests if necessary?
> Were any tests changed? Are any breaking changes necessary?

tests pass and nothing more has been added.

## Additional Information

> Any additional details that we should be aware of?

not i can think of.

## Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gaxios/issues/new/choose) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease
- [x] Appropriate docs were updated
- [x] Appropriate comments were added, particularly in complex areas or places that require background
- [x] No new warnings or issues will be generated from this change

Fixes #710  🦕
