### PR TITLE
fix: set tsconfig module to node16

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "module": "Preserve",
+    "module": "node16",
     "outDir": "build/esm"
   }
 }


### PR DESCRIPTION
Currently docs-dev is failing due to tsconfig module preserve.

ERROR: Error parsing tsconfig.json content: Argument for '--module' option must be: 'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'es2020', 'es2022', 'esnext', 'node16', 'nodenext'.

Changing to node16.