### PR TITLE
fix: Fix error handling to extract error information from the response body

### DIFF
--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -196,11 +196,11 @@ export class Gaxios implements FetchCompliance {
         if (opts.responseType === 'stream') {
           const response = [];
 
-          for await (const chunk of (opts.data ?? []) as Readable) {
+          for await (const chunk of (translatedResponse.data) as Readable) {
             response.push(chunk);
           }
 
-          translatedResponse.data = response as T;
+          translatedResponse.data = response.toString() as T;
         }
 
         const errorInfo = GaxiosError.extractAPIErrorFromResponse(

--- a/src/gaxios.ts
+++ b/src/gaxios.ts
@@ -196,7 +196,7 @@ export class Gaxios implements FetchCompliance {
         if (opts.responseType === 'stream') {
           const response = [];
 
-          for await (const chunk of (translatedResponse.data) as Readable) {
+          for await (const chunk of translatedResponse.data as Readable) {
             response.push(chunk);
           }
 


### PR DESCRIPTION
Fixes [regression in Gaxios response handling](https://github.com/googleapis/gaxios/commit/33702e6d3d470957bf40097d6235d13a75d14cb1#diff-1fbac0bfbd160f817d8a77140897b06cb53ff95f317bc9c3345afe4605fb3978L137-R136) where the _request method attempted to read the request body instead of the response body. This could probably use tests from a repo maintainer, because I'm not sure if this will affect other callers.

Unblocks googleapis/nodejs-firestore release

Fixes: b/429419330